### PR TITLE
remove the 0.3.0 foundery note since its forge 1.4.4-stable is workin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ chmod +x script/deploy-proof-of-human.sh
 ./script/deploy-proof-of-human.sh
 ```
 
-> **⚠️ Troubleshooting Celo Sepolia**: If you encounter a `Chain 11142220 not supported` error when using `celo-sepolia`, update Foundry to version 0.3.0:
+> ** Install foundery
 > ```bash
-> foundryup --install 0.3.0
+> foundryup
 > ```
 
 The script will:


### PR DESCRIPTION
remove the 0.3.0 foundry note since forge 1.4.4-stable is working with celo testnet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates README to replace the Celo Sepolia Foundry 0.3.0 note with generic `foundryup` install steps and fixes the Android app link bullet formatting.
> 
> - **Docs (`README.md`)**:
>   - Replace Celo Sepolia troubleshooting note about Foundry `0.3.0` with generic installation steps using `foundryup`.
>   - Fix formatting of the Android app link bullet in the "Self App" section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4d2e32b82209e43e0fb364b5ed43fd3452c056a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->